### PR TITLE
Report git version with library_version

### DIFF
--- a/crawl-ref/Makefile.libretro
+++ b/crawl-ref/Makefile.libretro
@@ -17,6 +17,10 @@ endif
 endif
 
 TARGET_NAME := stonesoup
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	CXXFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
 
 COMMONFLAGS :=
 

--- a/crawl-ref/libretro/libretro.cc
+++ b/crawl-ref/libretro/libretro.cc
@@ -226,7 +226,10 @@ void retro_set_environment(retro_environment_t cb) { environ_cb = cb; }
 void retro_get_system_info(struct retro_system_info *info)
 {
    info->library_name = "Dungeon Crawl: Stone Soup";
-   info->library_version = "git"; // < TODO
+#ifndef GIT_VERSION
+#define GIT_VERSION ""
+#endif
+   info->library_version = "git" GIT_VERSION;
    info->valid_extensions = "crawlrc";
    info->need_fullpath = true;
    info->block_extract = true;

--- a/crawl-ref/source/android-project/jni/src/Android.mk
+++ b/crawl-ref/source/android-project/jni/src/Android.mk
@@ -2,6 +2,11 @@ LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
 
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	LOCAL_CXXFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
+
 LOCAL_MODULE := main
 
 SDL_PATH := ../SDL2


### PR DESCRIPTION
This patch makes this core report the git version along with its library_version. This is important because otherwise it is impossible to replicate a build without extra knowledge, and things like Netplay that demand versions be the same can't be reliably known to work.